### PR TITLE
Add volume type for tasks dir

### DIFF
--- a/integration_poc/integration_poc.md
+++ b/integration_poc/integration_poc.md
@@ -74,9 +74,6 @@ The codebase on the `integration_poc` folder is an implementation of a V6 node i
 	task_dir: /<ouput_path>/tasks
 	```
 
-> [!IMPORTANT]
-> Do create the task folder on the machine where the v6 node will run. If you don't do this, Kubernetes will create it with root as the owner, which will cause problems as the JOB PODs don't have root privileges for creating sub-folders on it.
-
 7.  Edit the [Kubernetes YAML configuration file](kubeconfs/node_pod_config.yaml) used for launching the Node as a POD:
 
 	- Add the reference to the v6 node image (e.g., in Dockerhub) created in Step #5.
@@ -113,6 +110,7 @@ The codebase on the `integration_poc` folder is an implementation of a V6 node i
 	- name: task-files-root
 	  hostPath:
 	    path: ABSOLUTE_HOST_PATH_OF_THE_TASK_FOLDER
+        type: DirectoryOrCreate
 	```
 
 	- Add the absolute path of the kubernetes configuration file. This integration PoC has been tested with Ubuntu server 22.04 and MicroK8S, where such configuration file is by default on `/home/<user_name>/.kube/config`.

--- a/integration_poc/kubeconfs/node_pod_config.yaml
+++ b/integration_poc/kubeconfs/node_pod_config.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
  hostname: v6-node-pod       # a better name yet to be defined
  subdomain: v6-pod-subdomain # => POD FQDN: v6-node-pod.v6-pod-subdomain.v6-node
- hostAliases:      # only needed when working within a tailnet network          
+ hostAliases:      # only needed when working within a tailnet network
  - ip: "10.2.67.147"
    hostnames:
    - "v6-server.tail984a0.ts.net"
@@ -28,7 +28,7 @@ spec:
  - name: v6-node-server
    image: docker.io/hcadavidescience/v6_k8s_node:latest
    tty: true
-   ports: 
+   ports:
    - containerPort:  4567
    env:
    - name: HOST_IP # TODO check if this is necessary
@@ -36,13 +36,13 @@ spec:
        fieldRef:
          fieldPath: status.hostIP
    - name: PORT   # TODO check if this is necessary
-     value: "4567" 
+     value: "4567"
    command: ["python", "v6_k8s_node.py"]
    volumeMounts:
    - name: task-files-root
      mountPath: /app/tasks
    - name: kube-config-file
-     mountPath: /app/.kube/config  
+     mountPath: /app/.kube/config
    - name: v6-node-config-file
      mountPath: /app/.v6node/configs/node_legacy_config.yaml
    - name: v6-node-default-database
@@ -55,7 +55,7 @@ spec:
      type: DirectoryOrCreate
  - name: kube-config-file
    hostPath:
-     path: /home/hcadavid/.kube/config   
+     path: /home/hcadavid/.kube/config
  - name: v6-node-config-file
    hostPath:
      path: /home/hcadavid/k8s/v6-on-kubernetes-PoC/integration_poc/configs/node_legacy_config.yaml
@@ -76,4 +76,3 @@ spec:
   - protocol: TCP
     port:  4567
     targetPort:  4567
-

--- a/integration_poc/kubeconfs/node_pod_config.yaml
+++ b/integration_poc/kubeconfs/node_pod_config.yaml
@@ -52,6 +52,7 @@ spec:
  - name: task-files-root
    hostPath:
      path: /tmp/tasks
+     type: DirectoryOrCreate
  - name: kube-config-file
    hostPath:
      path: /home/hcadavid/.kube/config   


### PR DESCRIPTION
Add volume type `DirectoryOrCreate` for `/tmp/tasks/` folder to ensure automatic creation of the folder if not exist. Details see https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types.

I have tested the auto creation and it works well even the owner of the folder is `root`: 

![image](https://github.com/user-attachments/assets/3c513b04-67cf-4841-8154-49b3650c8702)

