### PR TITLE
Node K8S YAML file and Network policies based on the added role tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 #.idea/
 
 img/*.bkp
+integration_poc/network-diagnostics/config.py

--- a/integration_poc/kubeconfs/node_pod_config.yaml
+++ b/integration_poc/kubeconfs/node_pod_config.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,13 +18,14 @@ metadata:
  namespace: v6-jobs
  labels:
    app: v6-node-server-proxy
+   role: v6-node
 spec:
  hostname: v6-node-pod       # a better name yet to be defined
  subdomain: v6-pod-subdomain # => POD FQDN: v6-node-pod.v6-pod-subdomain.v6-node
  hostAliases:      # only needed when working within a tailnet network
- - ip: "10.2.67.147"
+ - ip: "10.2.67.221"
    hostnames:
-   - "v6-server.tail984a0.ts.net"
+   - "v6-rserver.tail984a0.ts.net"
  containers:
  - name: v6-node-server
    image: docker.io/hcadavidescience/v6_k8s_node:latest

--- a/integration_poc/kubeconfs/node_pod_network_policies.yaml
+++ b/integration_poc/kubeconfs/node_pod_network_policies.yaml
@@ -13,40 +13,51 @@ metadata:
 
 ---
 
-kind: NetworkPolicy # Policy to disable job's networking, except with the Node
 apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
 metadata:
-  name: v6-jobs-allow-egress-to-node-proxy-only
+  name: v6-alg-runner-policy
   namespace: v6-jobs
 spec:
-  podSelector: {} # This selects all pods in the v6-jobs namespace
+  podSelector:
+    matchLabels:
+      role: v6_alg_runner
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: v6-node-server-proxy
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: v6-node-server-proxy
+    ports:
+    - protocol: TCP
+      port:  4567 
+  - to:
+    - namespaceSelector: {} # allow only the use DNS within the cluster
+    ports:
+    - protocol: UDP #This enables internal DNS resolution (otherwhise the static IP addresses of the proxy should be given)
+      port: 53
+
+---
+
+# Policies for the node POD 
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: v6-node-policy
+  namespace: v6-jobs
+spec:
+  podSelector:
+    matchLabels:
+      role: v6-node
   policyTypes:
   - Egress
   egress:
   - {}
-#  - to:
-#    - podSelector:
-#        matchLabels:
-#          app: v6-node-server-proxy # This targets the dummy-v6-proxy pod
-#    ports:
-#    - protocol: TCP
-#      port:  4567 
-#  - to:
-#    - namespaceSelector: {} # allow only the use DNS within the cluster
-#    ports:
-#    - protocol: UDP #This enables internal DNS resolution (otherwhise the static IP addresses of the proxy should be given)
-#      port: 53
-
-
-
-#spec:
-#  podSelector:
-#    matchLabels:
-#      app: v6-node-server-proxy
-#  policyTypes:
-#  - Egress
-#  egress:
-#  - {} # This rule allows egress traffic to any destination (could be restricted to the V6-server only)
-
-
 


### PR DESCRIPTION
Node K8S YAML file and Network policies based on the added role tags - all outbound traffic from the algorithms, with exception of DNS servers (required to solve the FQDN) is blocked. This should be further improved to allow only the local K8S DNS